### PR TITLE
fix Cannot read property length of null when first init

### DIFF
--- a/backend/model/spider.go
+++ b/backend/model/spider.go
@@ -116,6 +116,10 @@ func GetSpiderList(filter interface{}, skip int, limit int) ([]Spider, int, erro
 		return spiders, 0, err
 	}
 
+    if spiders == nil {
+        spiders = []Spider{}
+    }
+
 	// 遍历爬虫列表
 	for i, spider := range spiders {
 		// 获取最后一次任务

--- a/frontend/src/views/schedule/ScheduleList.vue
+++ b/frontend/src/views/schedule/ScheduleList.vue
@@ -274,7 +274,7 @@ export default {
     // 爬虫列表
     request.get('/spiders', {})
       .then(response => {
-        this.spiderList = response.data.data.list
+        this.spiderList = response.data.data.list || []
       })
   }
 }


### PR DESCRIPTION
后台查询爬虫列表的接口list的值为nil，这样前端判断spiders.lengh就会报错，导致添加任务按钮点击没反应（估计是刚开始mongodb没有创建爬虫对应结构，导致查询为空）

这里修改了前端和后端，对go不是很了解，不知道改的是否有问题