### PR TITLE
bug fix:修复手动或者自动删除日志后的报错

### DIFF
--- a/backend/services/task.go
+++ b/backend/services/task.go
@@ -468,6 +468,29 @@ func GetTaskLog(id string) (logStr string, err error) {
 	}
 
 	if IsMasterNode(task.NodeId.Hex()) {
+		if !utils.Exists(task.LogPath) {
+			fileDir, err := MakeLogDir(task)
+
+			if err != nil {
+				log.Errorf(err.Error())
+			}
+
+			fileP := GetLogFilePaths(fileDir)
+
+			// 获取日志文件路径
+			fLog, err := os.Create(fileP)
+			defer fLog.Close()
+			if err != nil {
+				log.Errorf("create task log file error: %s", fileP)
+				debug.PrintStack()
+			}
+			task.LogPath = fileP
+			if err := task.Save(); err != nil {
+				log.Errorf(err.Error())
+				debug.PrintStack()
+			}
+
+		}
 		// 若为主节点，获取本机日志
 		logBytes, err := model.GetLocalLog(task.LogPath)
 		if err != nil {


### PR DESCRIPTION
<img width="1420" alt="截屏2019-11-2911 33 27" src="https://user-images.githubusercontent.com/7600925/69846609-89e0a880-12af-11ea-8426-5699d1f16885.png">
手动或者定时删除日志后，会找不到原来的日志文件夹，导致报错。
一开始先检查一下，如果不存在日志文件夹就创建一下并更新task的LogPath.