### PR TITLE
reduce  image layer

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -14,10 +14,9 @@ ADD ./frontend /app
 WORKDIR /app
 
 # install frontend
-RUN npm config set unsafe-perm true
-RUN npm install -g yarn && yarn install --registry=https://registry.npm.taobao.org
-
-RUN npm run build:prod
+RUN npm config set unsafe-perm true \
+	&& npm install -g yarn && yarn install --registry=https://registry.npm.taobao.org \
+	&& npm run build:prod
 
 # images
 FROM ubuntu:latest
@@ -28,19 +27,16 @@ ADD . /app
 ENV DEBIAN_FRONTEND noninteractive
 
 # install packages
-RUN apt-get update \
-	&& apt-get install -y curl git net-tools iputils-ping ntp ntpdate python3 python3-pip \
+RUN dependencies='curl git net-tools iputils-ping ntp ntpdate python3 python3-pip nginx' \
+	&& apt-get update \
+	&& apt-get install -y $dependencies \
 	&& ln -s /usr/bin/pip3 /usr/local/bin/pip \
-	&& ln -s /usr/bin/python3 /usr/local/bin/python
-
-# install backend
-RUN pip install scrapy pymongo bs4 requests -i https://pypi.tuna.tsinghua.edu.cn/simple
+	&& ln -s /usr/bin/python3 /usr/local/bin/python \
+	&& pip install scrapy pymongo bs4 requests -i https://pypi.tuna.tsinghua.edu.cn/simple \
+	&& apt-get clean
 
 # copy backend files
 COPY --from=backend-build /go/bin/crawlab /usr/local/bin
-
-# install nginx
-RUN apt-get -y install nginx
 
 # copy frontend files
 COPY --from=frontend-build /app/dist /app/dist


### PR DESCRIPTION
优化 Dockerfile:

- 每一个 `RUN`  会新建立一层，在其上执行这些命令，执行结束后，commit 这一层的修改，构成新的镜像。多个 RUN 合并可以减小镜像大小。
- `curl git net-tools iputils-ping ntp ntpdate` 这些包导致整个镜像臃肿，但是暂时没去掉，不知道有什么用处
- `nginx` 可以单独放在 `docker-compose.yml` 文件里编排，而不是直接安装在镜像

---

- `docker history <image>` 可以查看镜像创建历史