### PR TITLE
lastest ubuntu image cause error

### DIFF
--- a/Dockerfile.local
+++ b/Dockerfile.local
@@ -20,7 +20,7 @@ RUN npm install -g yarn && yarn install --registry=https://registry.npm.taobao.o
 RUN npm run build:prod
 
 # images
-FROM ubuntu:latest
+FROM ubuntu:16.04
 
 ADD . /app
 


### PR DESCRIPTION
lastest ubuntu image cause error:

```
Some packages could not be installed. This may mean that you have
requested an impossible situation or if you are using the unstable
distribution that some required packages have not yet been created
or been moved out of Incoming.
The following information may help to resolve the situation:

The following packages have unmet dependencies:
 git : Depends: liberror-perl but it is not going to be installed
 iputils-ping : Depends: libgnutls-openssl27 but it is not going to be installed
E: Unable to correct problems, you have held broken packages.
The command '/bin/sh -c apt-get update  && apt-get install -y curl git net-tools iputils-ping ntp ntpdate python3 python3-pip   && ln -s /usr/bin/pip3 /usr/local/bin/pip       && ln -s /usr/bin/python3 /usr/local/bin/python' returned a non-zero code: 100
```

set ubuntu version to 16.04 fixed this issue