### PR TITLE
fix(backend): redis sub error

### DIFF
--- a/backend/database/pubsub.go
+++ b/backend/database/pubsub.go
@@ -58,9 +58,9 @@ func (r *Redis) subscribe(ctx context.Context, consume ConsumeFunc, channel ...s
 			}
 			done <- nil
 		case <-tick.C:
-			//fmt.Printf("ping message  \n")
 			if err := psc.Ping(""); err != nil {
-				done <- err
+				fmt.Printf("ping message error: %s \n", err)
+				//done <- err
 			}
 		case err := <-done:
 			close(done)


### PR DESCRIPTION
修复redis连接池订阅消息失败时，因为ping操作优先获取到错误造成chan提前关闭引发panic的问题
fixed #340 