### PR TITLE
一点小优化

### DIFF
--- a/backend/database/redis.go
+++ b/backend/database/redis.go
@@ -107,7 +107,7 @@ func (r *Redis) HKeys(collection string) ([]string, error) {
 	c := r.pool.Get()
 	defer utils.Close(c)
 
-	value, err2 := redis.Strings(c.Do("HKeys", collection))
+	value, err2 := redis.Strings(c.Do("HKEYS", collection))
 	if err2 != nil {
 		log.Error(err2.Error())
 		debug.PrintStack()
@@ -208,7 +208,7 @@ func (r *Redis) Lock(lockKey string) (int64, error) {
 		debug.PrintStack()
 		return 0, err
 	}
-	if err == nil && ok == nil {
+	if ok == nil {
 		log.Errorf("the lockKey is locked: key=%s", lockKey)
 		return 0, errors.New("the lockKey is locked")
 	}


### PR DESCRIPTION
1.HKEYS改为全大写
2.不需要判断err == nil，因为前面已经判断了err  != nil，所以这里的err 肯定为 nil
```
        ok, err := c.Do("SET", lockKey, ts, "NX", "PX", 30000)
	if err != nil {  // 这里判断了err != nil
		log.Errorf("get lock fail with error: %s", err.Error())
		debug.PrintStack()
		return 0, err
	}
	if ok == nil { // 所以这里的err肯定为nil
		log.Errorf("the lockKey is locked: key=%s", lockKey)
		return 0, errors.New("the lockKey is locked")
	}
```