### PR TITLE
Update spider.py

### DIFF
--- a/backend/template/scrapy/config_spider/spiders/spider.py
+++ b/backend/template/scrapy/config_spider/spiders/spider.py
@@ -9,7 +9,7 @@ def get_real_url(response, url):
         return url
     elif re.search(r'^\/\/', url):
         u = urlparse(response.url)
-        return u.scheme + url
+        return u.scheme + ":" + url
     return urljoin(response.url, url)
 
 class ConfigSpider(scrapy.Spider):


### PR DESCRIPTION
修复“//” 开头的url报错   ValueError('Missing scheme in request url: %s' % self._url)