### PR TITLE
当Demo爬虫有误时删除已复制的文件；修复Demo中的链家网爬虫

### DIFF
--- a/backend/services/spider.go
+++ b/backend/services/spider.go
@@ -517,6 +517,7 @@ func InitDemoSpiders() {
 		yamlFile, err := ioutil.ReadFile(path.Join(spiderPath, "Spiderfile"))
 		if err != nil {
 			log.Errorf("read yaml error: " + err.Error())
+			utils.RemoveFiles(spiderPath)
 			//debug.PrintStack()
 			continue
 		}
@@ -582,6 +583,8 @@ func InitDemoSpiders() {
 				debug.PrintStack()
 				continue
 			}
+		} else {
+		    utils.RemoveFiles(spiderPath)
 		}
 	}
 

--- a/backend/template/spiders/realestate/Spiderfile
+++ b/backend/template/spiders/realestate/Spiderfile
@@ -1,4 +1,5 @@
 name: "realestate"
 display_name: "链家网 (Scrapy)"
 col: "results_realestate"
+type: "customized"
 cmd: "scrapy crawl lianjia"


### PR DESCRIPTION
1.当Demo爬虫有误时删除已复制的文件;
2.修复Demo中的链家网爬虫。