### PR TITLE
add backend install script execute privilege and fixed nodejs with the deprecated libssl1.0-dev

### DIFF
--- a/backend/scripts/install-nodejs.sh
+++ b/backend/scripts/install-nodejs.sh
@@ -10,9 +10,8 @@ touch /tmp/install.lock
 touch /tmp/install-nodejs.lock
 
 # install node.js
-curl -sL https://deb.nodesource.com/setup_10.x | bash -
-apt-get update && apt install -y nodejs nodejs-dev node-gyp libssl1.0-dev
-apt-get update && apt install -y npm
+curl -sL https://deb.nodesource.com/setup_12.x | bash -
+apt-get update && apt install -y nodejs 
 
 # install chromium
 # See https://crbug.com/795759

--- a/docker_init.sh
+++ b/docker_init.sh
@@ -22,6 +22,9 @@ fi
 # start nginx
 service nginx start
 
+#grant script 
+chmod +x /app/backend/scripts/*.sh
+
 # install languages
 if [ "${CRAWLAB_SERVER_LANG_NODE}" = "Y" ] || [ "${CRAWLAB_SERVER_LANG_JAVA}" = "Y" ] || [ "${CRAWLAB_SERVER_LANG_DOTNET}" = "Y" ] || [ "${CRAWLAB_SERVER_LANG_PHP}" = "Y" ] || [ "${CRAWLAB_SERVER_LANG_GO}" = "Y" ];
 then


### PR DESCRIPTION
hello, 由于最新docker ubuntu版本(19+)弃用libssl1.0-dev, yum上的 npm会用到node-leagcy, 引起依赖冲突，其实ubuntu node LTS (10+)已经自带NPM，不需要特别安装。更换LTS 12+更好。
<img width="640" alt="WX20200916-112558@2x" src="https://user-images.githubusercontent.com/3113374/93290391-324a0400-f813-11ea-8281-c323dc763354.png">
还有容器下的scripts下有部分script 没有execute权限，所以在init下增加chmod，近来的都没有法子安装 如webdriver等等。
![image](https://user-images.githubusercontent.com/3113374/93290433-4e4da580-f813-11ea-8d69-ba6740fff70d.png)


