### PR TITLE
修复git clone submodules

### DIFF
--- a/backend/services/git.go
+++ b/backend/services/git.go
@@ -12,6 +12,8 @@ import (
 	"gopkg.in/src-d/go-git.v4/config"
 	"gopkg.in/src-d/go-git.v4/plumbing"
 	"gopkg.in/src-d/go-git.v4/plumbing/object"
+	"gopkg.in/src-d/go-git.v4/plumbing/transport"
+	"gopkg.in/src-d/go-git.v4/plumbing/transport/http"
 	"gopkg.in/src-d/go-git.v4/plumbing/transport/ssh"
 	"gopkg.in/src-d/go-git.v4/storage/memory"
 	"io/ioutil"
@@ -269,7 +271,7 @@ func SyncSpiderGit(s model.Spider) (err error) {
 	}
 
 	// 生成验证信息
-	var auth ssh.AuthMethod
+	var auth transport.AuthMethod
 	if !strings.HasPrefix(s.GitUrl, "http") {
 		// 为 SSH
 		regex := regexp.MustCompile("^(?:ssh://?)?([0-9a-zA-Z_]+)@")
@@ -288,6 +290,11 @@ func SyncSpiderGit(s model.Spider) (err error) {
 			debug.PrintStack()
 			SaveSpiderGitSyncError(s, err.Error())
 			return err
+		}
+	} else {
+		// 为 HTTP
+		if s.GitUsername != "" && s.GitPassword != "" {
+			auth = &http.BasicAuth{s.GitUsername, s.GitPassword}
 		}
 	}
 


### PR DESCRIPTION
尝试解决以下问题：
测试当前版本配置爬虫git后，未拉取子模块submodule代码，相当于执行了
git clone XXX.git
可考虑修改为
git clone --recursive XXX.git

接之前的一次修改 https://github.com/crawlab-team/crawlab/pull/884
上次修改后，经过测试发现修复不够完整，在http版本的submodule代码库路径需要用户名密码认证访问时，会报错无权限。原因在于当前代码的auth变量为空。

当前代码路径中有 gitUrl = formatGitUrl(s.GitUrl, s.GitUsername, s.GitPassword) 只对主代码路径加了认证信息，submodule库访问时未包含{s.GitUsername, s.GitPassword}信息。

修改后测试可达到预期效果，如下图comm_lib_py子模块：
![2222](https://user-images.githubusercontent.com/20338457/102320312-16433380-3fb7-11eb-964d-3211b107e3af.jpg)

![11111111111111](https://user-images.githubusercontent.com/20338457/102319979-a634ad80-3fb6-11eb-9f8a-3fac2d8409fd.jpg)
