### PR TITLE
调整 git clean reset的顺序

### DIFF
--- a/vcs/git.go
+++ b/vcs/git.go
@@ -3,9 +3,7 @@ package vcs
 import (
 	"github.com/apex/log"
 	"github.com/crawlab-team/crawlab/trace"
-	"github.com/go-git/go-billy/v5"
 	"github.com/go-git/go-billy/v5/memfs"
-	"github.com/go-git/go-git/v5"
 	"github.com/go-git/go-git/v5/config"
 	"github.com/go-git/go-git/v5/plumbing"
 	"github.com/go-git/go-git/v5/plumbing/object"
@@ -220,13 +218,13 @@ func (c *GitClient) Reset(opts ...GitResetOption) (err error) {
 		return err
 	}
 
-	// reset
-	if err := wt.Reset(o); err != nil {
+	// clean
+	if err := wt.Clean(&git.CleanOptions{Dir: true}); err != nil {
 		return err
 	}
 
-	// clean
-	if err := wt.Clean(&git.CleanOptions{Dir: true}); err != nil {
+	// reset
+	if err := wt.Reset(o); err != nil {
 		return err
 	}
 

--- a/vcs/git.go
+++ b/vcs/git.go
@@ -3,7 +3,9 @@ package vcs
 import (
 	"github.com/apex/log"
 	"github.com/crawlab-team/crawlab/trace"
+	"github.com/go-git/go-billy/v5"
 	"github.com/go-git/go-billy/v5/memfs"
+	"github.com/go-git/go-git/v5"
 	"github.com/go-git/go-git/v5/config"
 	"github.com/go-git/go-git/v5/plumbing"
 	"github.com/go-git/go-git/v5/plumbing/object"


### PR DESCRIPTION
在阿里云NAS挂载环境下
对文件操作会产生 .nas临时文件
如果先reset后立刻clean  会将reset产生的临时文件删除,导致文件异常
因此这里希望先clean后再reset,这样reset产生的同步临时文件能够保留

